### PR TITLE
[#9] Add opacity to Consensus 2018 as the event has already been completed

### DIFF
--- a/components/constants/community.js
+++ b/components/constants/community.js
@@ -10,12 +10,6 @@ export const mediaContentJoin={
 
 export const eventDesc = [
   {
-    title: 'Consensus',
-    description: 'New York City, May 14-16',
-    imageSrc: '/static/social/mybit_facebook_cover.png',
-    imageAlt: 'Sample image'
-  },
-  {
     title: 'Blockchain Expo',
     description: 'Amsterdam, June 27-28',
     imageSrc: '/static/social/mybit_facebook_cover.png',


### PR DESCRIPTION
fixed [#9](https://github.com/MyBitFoundation/mybit-issues/issues/9)

_Summary_
The event date that has passed has been removed from the community page.


